### PR TITLE
Fix: onSubmitted not triggered when returnKeyType specified

### DIFF
--- a/example/lib/more_use_case_listing_page.dart
+++ b/example/lib/more_use_case_listing_page.dart
@@ -63,6 +63,7 @@ class _MoreUseCaseListingPageState extends State<MoreUseCaseListingPage> {
                   child: NativeTextInput(
                     minLines: 3,
                     maxLines: 5,
+                    returnKeyType: ReturnKeyType.done,
                     onChanged: _onChangeText,
                     onSubmitted: _onSubmittedText,
                   )),

--- a/ios/Classes/NativeTextInputDelegate.m
+++ b/ios/Classes/NativeTextInputDelegate.m
@@ -136,8 +136,8 @@
 }
 
  - (BOOL)textView:(UITextView *)textView shouldChangeTextInRange:(NSRange)range replacementText:(NSString *)text {
-     if (
-         textView.textContainer.maximumNumberOfLines == 1 &&
+     if ((textView.returnKeyType != UIReturnKeyDefault ||
+         textView.textContainer.maximumNumberOfLines == 1) &&
          [text isEqualToString:@"\n"]
      ) {
          [textView resignFirstResponder];


### PR DESCRIPTION
This PR includes the following change:
-  fixed `onSubmitted` not triggered when `returnKeyType` specified

Resolves #14 